### PR TITLE
Refactor split reader/file functions

### DIFF
--- a/split_file.go
+++ b/split_file.go
@@ -1,6 +1,7 @@
 package codeintelutils
 
 import (
+	"bytes"
 	"io"
 	"io/ioutil"
 	"os"
@@ -19,14 +20,14 @@ func SplitFile(filename string, maxPayloadSize int) (files []string, _ func(erro
 	}
 	defer f.Close()
 
-	return SplitReader(f, maxPayloadSize)
+	return SplitReaderIntoFiles(f, maxPayloadSize)
 }
 
-// SplitReader writes the contents of the given reader into a series of temporary files, each of which
+// SplitReaderIntoFiles writes the contents of the given reader into a series of temporary files, each of which
 // are gzipped and are no larger than the given max payload size. The file names are returned in the
 // order in which they were written. The cleanup function removes all temporary files, and wraps the
 // error argument with any additional errors that happen during cleanup.
-func SplitReader(r io.Reader, maxPayloadSize int) (files []string, _ func(error) error, err error) {
+func SplitReaderIntoFiles(r io.ReaderAt, maxPayloadSize int) (files []string, _ func(error) error, err error) {
 	cleanup := func(err error) error {
 		for _, file := range files {
 			if removeErr := os.Remove(file); removeErr != nil {
@@ -42,6 +43,9 @@ func SplitReader(r io.Reader, maxPayloadSize int) (files []string, _ func(error)
 		}
 	}()
 
+	// Create a function that returns a reader of the "next" chunk on each invocation.
+	makeNextReader := SplitReader(r, maxPayloadSize)
+
 	for {
 		partFile, err := ioutil.TempFile("", "")
 		if err != nil {
@@ -49,14 +53,12 @@ func SplitReader(r io.Reader, maxPayloadSize int) (files []string, _ func(error)
 		}
 		defer partFile.Close()
 
-		n, err := io.CopyN(partFile, r, int64(maxPayloadSize))
-		if err != nil && err != io.EOF {
+		n, err := io.Copy(partFile, makeNextReader())
+		if err != nil {
 			return nil, nil, err
 		}
 
-		if n > 0 {
-			files = append(files, partFile.Name())
-		} else {
+		if n == 0 {
 			// File must be closed before it's removed (on Windows), so
 			// don't wait for the defer above. Double closing a file is
 			// fine, but the second close will return an ErrClosed value,
@@ -69,12 +71,63 @@ func SplitReader(r io.Reader, maxPayloadSize int) (files []string, _ func(error)
 			if err := os.Remove(partFile.Name()); err != nil {
 				return nil, nil, err
 			}
-		}
 
-		if err == io.EOF {
+			// Reader was empty, nothing left to do in this loop
 			break
 		}
+
+		files = append(files, partFile.Name())
 	}
 
 	return files, cleanup, nil
+}
+
+// SplitReader returns a function that returns readers that return a slice of the reader
+// at maxPayloadSize bytes long. Each reader returned will operate on the next sequential
+// slice from the source reader.
+func SplitReader(r io.ReaderAt, maxPayloadSize int) func() io.Reader {
+	offset := 0
+
+	return func() io.Reader {
+		pr, pw := io.Pipe()
+
+		go func() {
+			n, err := readAtN(pw, r, offset, maxPayloadSize)
+			offset += n
+			pw.CloseWithError(err)
+		}()
+
+		return pr
+	}
+}
+
+// readAtN reads n bytes (or until EOF) from the given ReaderAt starting at the given offset.
+// Each chunk read from the reader is written to the writer. Errors are forwarded from both
+// the reader and writer.
+func readAtN(w io.Writer, r io.ReaderAt, offset, n int) (int, error) {
+	buf := make([]byte, 32*1024) // same as used by io.Copy/copyBuffer
+
+	totalRead := 0
+	for n > 0 {
+		if n < len(buf) {
+			buf = buf[:n]
+		}
+
+		read, readErr := r.ReadAt(buf, int64(offset+totalRead))
+		if readErr != nil && readErr != io.EOF {
+			return totalRead, readErr
+		}
+
+		n -= read
+		totalRead += read
+
+		if _, writeErr := io.Copy(w, bytes.NewReader(buf[:read])); writeErr != nil {
+			return totalRead, writeErr
+		}
+		if readErr != nil {
+			return totalRead, readErr
+		}
+	}
+
+	return totalRead, nil
 }

--- a/stitch_files.go
+++ b/stitch_files.go
@@ -34,7 +34,7 @@ func StitchFiles(filename string, makePartFilename PartFilenameFunc, compress bo
 	return err
 }
 
-// StitchFilesReader combines multiple compressed file parts into a single reader. Each part on disk be
+// StitchFilesReader combines multiple compressed file parts into a single reader. Each part on disk is
 // concatenated into a single file. The content of each part is decompressed and written to returned
 // reader sequentially. On success, the part files are removed.
 func StitchFilesReader(makePartFilename PartFilenameFunc, compress bool) (io.Reader, error) {


### PR DESCRIPTION
Refactor reader/file split utility functions so that we can split readers into a sequence of readers, not just a sequence of files. This is a first step from not having to write to disk temporarily when uploading parts.