### PR TITLE
Only retry network and 500-level responses during uploads

### DIFF
--- a/upload.go
+++ b/upload.go
@@ -304,7 +304,7 @@ func makeUploadRequest(args requestArgs, payload io.Reader, target *int) (bool, 
 
 		// Do not retry client errors
 		err = fmt.Errorf("unexpected status code: %d\n\n%s", resp.StatusCode, body)
-		return resp.StatusCode < 500, err
+		return resp.StatusCode >= 500, err
 	}
 
 	if target != nil {


### PR DESCRIPTION
The current upload logic will retry each request up to 10 times with a sleep in between attempts. This is bad if the reason for the error is a 400-level error (in which case retrying does not help and simply delays the error message to the user).

This makes retires only happen on network and 500-level error codes.